### PR TITLE
Add support for imperial units

### DIFF
--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -1,15 +1,9 @@
 <template>
-  <v-navigation-drawer app dark clipped permanent width="300">
+  <v-navigation-drawer app dark clipped permanent width="300" class="navigation-panel">
     <v-alert v-if="!active" dense text type="info" class="mx-2 mt-2 caption">
-      Plug in CATS board and connect to activate this panel.
+      Plug in CATS board and connect to activate this area.
     </v-alert>
-    <v-alert
-      v-if="changedTab"
-      dense
-      text
-      type="warning"
-      class="mx-2 mt-2 caption"
-    >
+    <v-alert v-if="changedTab" dense text type="warning" class="mx-2 mt-2 caption">
       <div class="d-flex justify-space-between align-center">
         <div>Unsaved changes.</div>
         <v-btn small text @click="discard">discard</v-btn>
@@ -26,6 +20,7 @@
         </v-list-item-group>
       </v-list>
     </v-card>
+    <UnitSwitch class="unit-switch" />
   </v-navigation-drawer>
 </template>
 
@@ -35,9 +30,13 @@ import { getConfigs } from "@/services/configService";
 import { getEvents } from "@/services/eventService";
 import { getTimers } from "@/services/timerService";
 import { getLogData } from "@/services/logService";
+import UnitSwitch from "./UnitSwitch.vue";
 
 export default {
   name: "NavigationPanel",
+  components: {
+    UnitSwitch,
+  },
   props: {
     items: {
       type: Array,
@@ -71,4 +70,13 @@ export default {
 };
 </script>
 
-<style></style>
+<style scoped>
+.navigation-panel ::v-deep .v-navigation-drawer__content {
+  display: flex;
+  flex-direction: column;
+}
+
+.unit-switch {
+  margin-top: auto;
+}
+</style>

--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-navigation-drawer app dark clipped permanent width="300" class="navigation-panel">
+  <v-navigation-drawer app dark clipped permanent width="300" class="navigation-panel pb-4">
     <v-alert v-if="!active" dense text type="info" class="mx-2 mt-2 caption">
       Plug in CATS board and connect to activate this area.
     </v-alert>
@@ -20,7 +20,7 @@
         </v-list-item-group>
       </v-list>
     </v-card>
-    <UnitSwitch class="unit-switch" />
+    <UnitSwitch class="unit-switch mb-2" />
   </v-navigation-drawer>
 </template>
 

--- a/src/components/UnitSwitch.vue
+++ b/src/components/UnitSwitch.vue
@@ -1,0 +1,48 @@
+<template>
+  <v-container class="py-0">
+    <v-row align="center" justify="start">
+      <v-col cols="auto">
+        <v-switch v-model="useImperialUnitsState" label="Use imperial units" hide-details inset class="mt-0 pt-0"
+          color="primary"></v-switch>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex';
+
+export default {
+  name: 'UnitSwitch',
+  computed: {
+    ...mapGetters(['useImperialUnits']),
+    useImperialUnitsState: {
+      get() {
+        return this.useImperialUnits;
+      },
+      set(newValue) {
+        this.toggleUnitSystem();
+      }
+    }
+  },
+  methods: {
+    ...mapActions(['toggleUnitSystem']),
+  }
+};
+</script>
+
+<style scoped>
+/* These styles help align the switch better within its container */
+.v-input--switch.mt-0 {
+  margin-top: 0 !important;
+}
+
+.v-input--switch.pt-0 {
+  padding-top: 0 !important;
+}
+
+/* You can adjust margin-right if the label is too close to the switch thumb */
+.v-input--switch .v-label {
+  margin-right: 8px;
+}
+</style>

--- a/src/components/UnitSwitch.vue
+++ b/src/components/UnitSwitch.vue
@@ -5,6 +5,18 @@
         <v-switch v-model="useImperialUnitsState" label="Use imperial units" hide-details inset class="mt-0 pt-0"
           color="primary"></v-switch>
       </v-col>
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+        <v-icon
+              color="primary"
+              v-on="on"
+              v-bind="attrs"
+            >
+              mdi-information-variant-box-outline
+            </v-icon>
+            </template>
+        <span>Configuration values using imperial system will be rounded to nearest whole metric value</span>
+      </v-tooltip>
     </v-row>
   </v-container>
 </template>

--- a/src/modules/plots.js
+++ b/src/modules/plots.js
@@ -240,7 +240,7 @@ export function makePlots(flightlog, element, useImperialUnits) {
 
     el = document.createElement("div")
     element.append(el)
-    const accelerationYLabel = useImperialUnits ? "Acceleration [ft/s^2]" : "Acceleration [m/s^2]"
+    const accelerationYLabel = useImperialUnits ? "Acceleration [ft/s²]" : "Acceleration [m/s²]"
     makePlot(flightlog.imu, el, "IMU - Acceleration", accelerationYLabel, ["Ax", "Ay", "Az"], eventInfo, useImperialUnits)
 
     el = document.createElement("div")

--- a/src/modules/plots.js
+++ b/src/modules/plots.js
@@ -1,20 +1,26 @@
 import Plotly from 'plotly.js-dist';
+import { getDisplayValue } from "@/utils/unitConversions.js";
 
 const COLOR = "rgb(100, 100, 100)"
 const EVENT_MAP = {
-  0: { name: "ev_moving", color: COLOR },
-  1: { name: "ev_ready", color: COLOR },
-  2: { name: "ev_liftoff", color: COLOR },
-  3: { name: "ev_burnout", color: COLOR },
-  4: { name: "ev_apogee", color: COLOR },
-  5: { name: "ev_main_deployment", color: COLOR },
-  6: { name: "ev_touchdown", color: COLOR },
-  7: { name: "ev_custom1", color: COLOR },
-  8: { name: "ev_custom2", color: COLOR },
+    0: { name: "ev_moving", color: COLOR },
+    1: { name: "ev_ready", color: COLOR },
+    2: { name: "ev_liftoff", color: COLOR },
+    3: { name: "ev_burnout", color: COLOR },
+    4: { name: "ev_apogee", color: COLOR },
+    5: { name: "ev_main_deployment", color: COLOR },
+    6: { name: "ev_touchdown", color: COLOR },
+    7: { name: "ev_custom1", color: COLOR },
+    8: { name: "ev_custom2", color: COLOR },
 }
 
+function adaptTraceNameForConverterFunction(name) {
+    if (name === 'height') return 'altitude';
+    if (name === 'filteredAltitudeAGL') return 'altitude';
+    return name;
+}
 
-function makePlot(data, elementId, title, ylabel, traceNames, eventInfo) {
+function makePlot(data, elementId, title, ylabel, traceNames, eventInfo, useImperialUnits) {
 
     let lines = []
     let x = []
@@ -31,6 +37,7 @@ function makePlot(data, elementId, title, ylabel, traceNames, eventInfo) {
         let i = 0;
         for (let key of traceNames) {
             let value = o[key]
+            if (useImperialUnits) value = getDisplayValue(value, adaptTraceNameForConverterFunction(key), "imperial")
             lines[i].y.push(value)
             i++;
         }
@@ -43,10 +50,10 @@ function makePlot(data, elementId, title, ylabel, traceNames, eventInfo) {
         elementId,
         lines,
         {
-            title: { text: title},
+            title: { text: title },
             margin: { t: 50 },
             xaxis: { title: "Timestamp [s]" },
-            yaxis: { title: ylabel },
+            yaxis: { title: ylabel, tickFormat: ',.0f' },
             shapes: eventInfo.shapes,
             annotations: eventInfo.annotations,
             template: 'plotly_dark',
@@ -199,7 +206,7 @@ function makeEventInfoTraces(flightlog) {
     return { shapes: shapes, annotations: annotations }
 }
 
-export function makePlots(flightlog, element) {
+export function makePlots(flightlog, element, useImperialUnits) {
     let eventInfo = makeEventInfoTraces(flightlog)
 
     element.replaceChildren([])
@@ -207,19 +214,18 @@ export function makePlots(flightlog, element) {
     let el = document.createElement("div")
     document.create
     element.append(el)
-    makePlot(flightlog.flightInfo, el, "State Estimation - Altitude", "Altitude [m]", ["height"], eventInfo)
+    const altitudeYLabel = useImperialUnits ? "Altitude [ft]" : "Altitude [m]"
+    makePlot(flightlog.flightInfo, el, "State Estimation - Altitude", altitudeYLabel, ["height"], eventInfo, useImperialUnits)
 
     el = document.createElement("div")
     element.append(el)
-    makePlot(flightlog.flightInfo, el, "State Estimation - Velocity", "Velocity [m/s]", ["velocity"], eventInfo)
-
-    // el = document.createElement("div")
-    // element.append(el)
-    // makePlot(flightlog.flightInfo, el, "Acceleration [m/s^2]", ["acceleration"], eventInfo)
+    const velocityYLabel = useImperialUnits ? "Velocity [ft/s]" : "Velocity [m/s]"
+    makePlot(flightlog.flightInfo, el, "State Estimation - Velocity", velocityYLabel, ["velocity"], eventInfo, useImperialUnits)
 
     el = document.createElement("div")
     element.append(el)
-    makePlot(flightlog.imu, el,  "IMU - Acceleration", "Acceleration [m/s^2]", ["Ax", "Ay", "Az"], eventInfo)
+    const accelerationYLabel = useImperialUnits ? "Acceleration [ft/s^2]" : "Acceleration [m/s^2]"
+    makePlot(flightlog.imu, el, "IMU - Acceleration", accelerationYLabel, ["Ax", "Ay", "Az"], eventInfo, useImperialUnits)
 
     el = document.createElement("div")
     element.append(el)
@@ -227,15 +233,18 @@ export function makePlots(flightlog, element) {
 
     el = document.createElement("div")
     element.append(el)
-    makePlot(flightlog.baro, el, "Temperature", "Temperature [°C]", ["T"], eventInfo)
+    const temperatureYLabel = useImperialUnits ? "Temperature [°F]" : "Temperature [°C]"
+    makePlot(flightlog.baro, el, "Temperature", temperatureYLabel, ["T"], eventInfo, useImperialUnits)
 
     el = document.createElement("div")
     element.append(el)
-    makePlot(flightlog.baro, el, "Pressure", "Pressure [hPa]", ["P"], eventInfo)
+    const pressureYLabel = useImperialUnits ? "Pressure [psi]" : "Pressure [hPa]"
+    makePlot(flightlog.baro, el, "Pressure", pressureYLabel, ["P"], eventInfo, useImperialUnits)
 
     el = document.createElement("div")
     element.append(el)
-    makePlot(flightlog.filteredDataInfo, el, "Filtered Barometer Altitude", "Altitude [m]", ["filteredAltitudeAGL"], eventInfo)
+    const filteredAltitudeYLabel = useImperialUnits ? "Altitude [ft]" : "Altitude [m]"
+    makePlot(flightlog.filteredDataInfo, el, "Filtered Barometer Altitude", filteredAltitudeYLabel, ["filteredAltitudeAGL"], eventInfo, useImperialUnits)
 
     el = document.createElement("div")
     element.append(el)

--- a/src/modules/plots.js
+++ b/src/modules/plots.js
@@ -16,9 +16,16 @@ const EVENT_MAP = {
 
 function adaptTraceNameForConverterFunction(name) {
     if (name === 'height') return 'altitude';
+    if (name === 'Ax') return 'acceleration';
+    if (name === 'Ay') return 'acceleration';
+    if (name === 'Az') return 'acceleration';
+    if (name === 'T') return 'temperature';
+    if (name === 'P') return 'pressure';
     if (name === 'filteredAltitudeAGL') return 'altitude';
     return name;
 }
+
+const TRACES_TO_CONVERT = ['height', 'acceleration', 'velocity', 'Ax', 'Ay', 'Az', 'T', 'P', 'filteredAltitudeAGL'];
 
 function makePlot(data, elementId, title, ylabel, traceNames, eventInfo, useImperialUnits) {
 
@@ -33,11 +40,20 @@ function makePlot(data, elementId, title, ylabel, traceNames, eventInfo, useImpe
             })
         }
     }
+
+    if (useImperialUnits) {
+        data = structuredClone(data)
+        for (const o of data) {
+            for (let key of traceNames.filter(value => TRACES_TO_CONVERT.includes(value))) {
+                o[key] = getDisplayValue(o[key], adaptTraceNameForConverterFunction(key));
+            }
+        }
+    }
+
     for (const o of data) {
         let i = 0;
         for (let key of traceNames) {
             let value = o[key]
-            if (useImperialUnits) value = getDisplayValue(value, adaptTraceNameForConverterFunction(key), "imperial")
             lines[i].y.push(value)
             i++;
         }

--- a/src/modules/settings.js
+++ b/src/modules/settings.js
@@ -43,16 +43,16 @@ export const EVENT_SETTINGS = [
 ];
 
 export const CONFIG_SETTINGS = {
-  main_altitude: {section: "general", name: "Main Altitude", unit: "m" },
-  acc_threshold: {section: "general", name: "Liftoff Detection Acceleration", unit: "m/s^2" },
-  servo1_init_pos: {section: "general", name: "Initial Position Servo 1", unit: "‰" },
-  servo2_init_pos: {section: "general", name: "Initial Position Servo 2", unit: "‰" },
-  tele_enable: {section: "telemetry", name: "Enable Telemetry", unit: null},
-  tele_link_phrase: {section: "telemetry", name: "Link Phrase", unit: null},
-  tele_power_level: {section: "telemetry", name: "Telemetry Power Level", unit: "dBm" },
-  tele_adaptive_power: {section: "telemetry", name: "Adaptive Power Level", unit: null},
-  test_mode: {section: "testing", name: "Enable Testing Mode", unit: null},
-  tele_test_phrase: {section: "testing", name: "Testing Phrase", unit: null},
+  main_altitude: { section: "general", name: "Main Altitude", unit: "m" },
+  acc_threshold: { section: "general", name: "Liftoff Detection Acceleration", unit: "m/s²" },
+  servo1_init_pos: { section: "general", name: "Initial Position Servo 1", unit: "‰" },
+  servo2_init_pos: { section: "general", name: "Initial Position Servo 2", unit: "‰" },
+  tele_enable: { section: "telemetry", name: "Enable Telemetry", unit: null },
+  tele_link_phrase: { section: "telemetry", name: "Link Phrase", unit: null },
+  tele_power_level: { section: "telemetry", name: "Telemetry Power Level", unit: "dBm" },
+  tele_adaptive_power: { section: "telemetry", name: "Adaptive Power Level", unit: null },
+  test_mode: { section: "testing", name: "Enable Testing Mode", unit: null },
+  tele_test_phrase: { section: "testing", name: "Testing Phrase", unit: null },
 };
 
 export const LOG_ELEMENTS = [

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -18,6 +18,7 @@ export default new Vuex.Store({
       rec_speed: {},
       rec_elements: {},
     },
+    useImperialUnits: false,
   },
   mutations: {
     SET_SERIAL_PORTS(state, ports) {
@@ -59,6 +60,9 @@ export default new Vuex.Store({
     SET_SUCCESS_MESSAGE(state, value) {
       state.successSetMessage = value;
     },
+    SET_USE_IMPERIAL_UNITS(state, value) {
+      state.useImperialUnits = value;
+    }
   },
   actions: {
     setSerialPorts({ commit }, ports) {
@@ -74,8 +78,8 @@ export default new Vuex.Store({
       if (!payload.key) return;
 
       payload.name = CONFIG_SETTINGS[payload.key]
-      ? CONFIG_SETTINGS[payload.key].name
-      : null;
+        ? CONFIG_SETTINGS[payload.key].name
+        : null;
 
       payload.unit = CONFIG_SETTINGS[payload.key]
         ? CONFIG_SETTINGS[payload.key].unit
@@ -124,6 +128,10 @@ export default new Vuex.Store({
       commit("SET_SUCCESS_MESSAGE", value);
       setTimeout(() => commit("SET_SUCCESS_MESSAGE", null), 5000);
     },
+    toggleUnitSystem({ commit, state }) {
+      const newValue = !state.useImperialUnits;
+      commit("SET_USE_IMPERIAL_UNITS", newValue);
+    },
   },
   getters: {
     isEventsChanged(state) {
@@ -144,5 +152,8 @@ export default new Vuex.Store({
 
       return changed;
     },
+    useImperialUnits(state) {
+      return state.useImperialUnits;
+    }
   },
 });

--- a/src/utils/unitConversions.js
+++ b/src/utils/unitConversions.js
@@ -131,26 +131,25 @@ export function convertTemperatureToMetric(fahrenheit) {
  *
  * @param {number} rawValue - The raw numeric value from the board (always in metric SI base units).
  * @param {string} paramName - The name of the parameter (e.g., 'altitude', 'acceleration').
- * @param {string} targetUnitSystem - The desired display unit system ('metric' or 'imperial').
  * @param {object} [options={}] - Optional display settings.
+ * @param {boolean} [options.numeric=true] - If true, returns a numeric value; if false, returns a formatted string.
  * @param {number} [options.decimals=2] - Number of decimal places for rounding.
- * @param {boolean} [options.displayInGs=false] - For 'acceleration', display in G-forces.
- * @param {boolean} [options.displayInBar=false] - For 'pressure', display in Bar.
- * @param {boolean} [options.displayInKelvin=false] - For 'temperature', display in Kelvin.
- * @returns {string} The formatted string with value and unit (e.g., "123.45 m", "3.2 g").
+ * @param {string} [options.targetUnitSystem='imperial'] - The target unit system for conversion ('metric' or 'imperial').
+ * @param {boolean} [options.excludeLabel=false] - If true, excludes the unit label from the returned string.
+ * @returns {number|string} The formatted value, either as a number or a string with unit label.
  */
-export function getDisplayValue(rawValue, paramName, targetUnitSystem, options = {}) {
+export function getDisplayValue(rawValue, paramName, options = {}) {
   // Handle null/undefined values
   if (rawValue === null || rawValue === undefined) {
-    return '-'; // Or 'N/A' or similar placeholder
+    return '-';
   }
 
   // Ensure options have defaults
-  const { decimals = 2, excludeLabel = false } = options;
-  const isTargetImperial = targetUnitSystem === 'imperial';
-  let valueToDisplay = parseFloat(rawValue);
+  const { numeric = true, decimals = 2, targetUnitSystem = "imperial", excludeLabel = false } = options;
+  let parsedValue = parseFloat(rawValue);
+  let convertedValue;
 
-  if (isNaN(valueToDisplay)) {
+  if (isNaN(parsedValue)) {
     return '-';
   }
 
@@ -158,24 +157,26 @@ export function getDisplayValue(rawValue, paramName, targetUnitSystem, options =
 
   switch (paramName) {
     case 'altitude':
-      valueToDisplay = convertLengthToImperial(rawValue);
+      convertedValue = convertLengthToImperial(rawValue);
       break;
     case 'velocity':
-      valueToDisplay = convertVelocityToImperial(rawValue);
+      convertedValue = convertVelocityToImperial(rawValue);
       break;
     case 'acceleration':
-      valueToDisplay = convertAccelerationToImperial(rawValue);
+      convertedValue = convertAccelerationToImperial(rawValue);
       break;
     case 'pressure':
-      valueToDisplay = convertPressureToImperial(rawValue);
+      convertedValue = convertPressureToImperial(rawValue);
       break;
     case 'temperature':
-      valueToDisplay = convertTemperatureToImperial(rawValue);
+      convertedValue = convertTemperatureToImperial(rawValue);
       break;
     default:
       break;
   }
   unitLabel = getUnitLabel(paramName, targetUnitSystem);
 
-  return options.excludeLabel ? `${valueToDisplay.toFixed(decimals)}` : `${valueToDisplay.toFixed(decimals)}${unitLabel}`
+  if (numeric) return convertedValue;
+
+  return options.excludeLabel ? `${convertedValue.toFixed(decimals)}` : `${convertedValue.toFixed(decimals)}${unitLabel}`
 }

--- a/src/utils/unitConversions.js
+++ b/src/utils/unitConversions.js
@@ -1,10 +1,8 @@
-// --- Conversion Constants ---
 const METERS_TO_FEET = 3.28084;
 const MPS_TO_FPS = 3.28084; // Meters per second to feet per second
 const MPS2_TO_FPS2 = 3.28084; // Meters per second squared to feet per second squared
 const PSI_TO_KPA = 6.89476; // Pounds per square inch to Kilopascals
 
-// --- Core Unit Label Getter ---
 /**
  * Gets the appropriate unit label for a given parameter and unit system.
  * @param {string} paramName - The name of the parameter (e.g., 'altitude', 'velocity').
@@ -20,19 +18,16 @@ export function getUnitLabel(paramName, unitSystem) {
     case 'velocity':
       return isImperial ? 'ft/s' : 'm/s';
     case 'acceleration':
-      return isImperial ? 'ft/s²' : 'm/s²'; // Base label for acceleration
+      return isImperial ? 'ft/s²' : 'm/s²';
     case 'pressure':
-      return isImperial ? 'psi' : 'kPa';   // Base label for pressure
+      return isImperial ? 'psi' : 'kPa';
     case 'temperature':
-      return isImperial ? '°F' : '°C';     // Base label for temperature
-    // Add more parameters as needed (e.g., 'angularVelocity', 'batteryVoltage')
+      return isImperial ? '°F' : '°C';
     default:
       console.warn(`Unknown parameter for unit label: ${paramName}`);
-      return ''; // Return empty for unknown parameters
+      return '';
   }
 }
-
-// --- Specific Value Conversion Functions (from Metric Base Units) ---
 
 /**
  * Converts length from meters to feet.
@@ -155,28 +150,54 @@ export function getDisplayValue(rawValue, paramName, options = {}) {
 
   let unitLabel = '';
 
-  switch (paramName) {
-    case 'altitude':
-      convertedValue = convertLengthToImperial(rawValue);
-      break;
-    case 'velocity':
-      convertedValue = convertVelocityToImperial(rawValue);
-      break;
-    case 'acceleration':
-      convertedValue = convertAccelerationToImperial(rawValue);
-      break;
-    case 'pressure':
-      convertedValue = convertPressureToImperial(rawValue);
-      break;
-    case 'temperature':
-      convertedValue = convertTemperatureToImperial(rawValue);
-      break;
-    default:
-      break;
+  if (targetUnitSystem === 'imperial') {
+    switch (paramName) {
+      case 'altitude':
+        convertedValue = convertLengthToImperial(rawValue);
+        break;
+      case 'velocity':
+        convertedValue = convertVelocityToImperial(rawValue);
+        break;
+      case 'acceleration':
+        convertedValue = convertAccelerationToImperial(rawValue);
+        break;
+      case 'pressure':
+        convertedValue = convertPressureToImperial(rawValue);
+        break;
+      case 'temperature':
+        convertedValue = convertTemperatureToImperial(rawValue);
+        break;
+      default:
+        convertedValue = rawValue;
+    }
+  } else if (targetUnitSystem === 'metric') {
+    switch (paramName) {
+      case 'altitude':
+        convertedValue = convertLengthToMetric(rawValue);
+        break;
+      case 'velocity':
+        convertedValue = convertVelocityToMetric(rawValue);
+        break;
+      case 'acceleration':
+        convertedValue = convertAccelerationToMetric(rawValue);
+        break;
+      case 'pressure':
+        convertedValue = convertPressureToMetric(rawValue);
+        break;
+      case 'temperature':
+        convertedValue = convertTemperatureToMetric(rawValue);
+        break;
+      default:
+        convertedValue = rawValue;
+    }
+  } else {
+    console.warn(`Unknown target unit system: ${targetUnitSystem}`);
+    return '-';
   }
+
   unitLabel = getUnitLabel(paramName, targetUnitSystem);
 
   if (numeric) return convertedValue;
 
-  return options.excludeLabel ? `${convertedValue.toFixed(decimals)}` : `${convertedValue.toFixed(decimals)}${unitLabel}`
+  return excludeLabel ? `${convertedValue.toFixed(decimals)}` : `${convertedValue.toFixed(decimals)}${unitLabel}`
 }

--- a/src/utils/unitConversions.js
+++ b/src/utils/unitConversions.js
@@ -1,0 +1,181 @@
+// --- Conversion Constants ---
+const METERS_TO_FEET = 3.28084;
+const MPS_TO_FPS = 3.28084; // Meters per second to feet per second
+const MPS2_TO_FPS2 = 3.28084; // Meters per second squared to feet per second squared
+const PSI_TO_KPA = 6.89476; // Pounds per square inch to Kilopascals
+
+// --- Core Unit Label Getter ---
+/**
+ * Gets the appropriate unit label for a given parameter and unit system.
+ * @param {string} paramName - The name of the parameter (e.g., 'altitude', 'velocity').
+ * @param {string} unitSystem - The desired unit system ('metric' or 'imperial').
+ * @returns {string} The unit label (e.g., 'm', 'ft', 'kPa', 'psi').
+ */
+export function getUnitLabel(paramName, unitSystem) {
+  const isImperial = unitSystem === 'imperial';
+
+  switch (paramName) {
+    case 'altitude':
+      return isImperial ? 'ft' : 'm';
+    case 'velocity':
+      return isImperial ? 'ft/s' : 'm/s';
+    case 'acceleration':
+      return isImperial ? 'ft/s²' : 'm/s²'; // Base label for acceleration
+    case 'pressure':
+      return isImperial ? 'psi' : 'kPa';   // Base label for pressure
+    case 'temperature':
+      return isImperial ? '°F' : '°C';     // Base label for temperature
+    // Add more parameters as needed (e.g., 'angularVelocity', 'batteryVoltage')
+    default:
+      console.warn(`Unknown parameter for unit label: ${paramName}`);
+      return ''; // Return empty for unknown parameters
+  }
+}
+
+// --- Specific Value Conversion Functions (from Metric Base Units) ---
+
+/**
+ * Converts length from meters to feet.
+ * @param {number} meters - Value in meters.
+ * @returns {number} Converted value.
+ */
+export function convertLengthToImperial(meters) {
+  return meters * METERS_TO_FEET;
+}
+
+/**
+ * Converts velocity from m/s to ft/s.
+ * @param {number} mps - Value in meters per second.
+ * @returns {number} Converted value.
+ */
+export function convertVelocityToImperial(mps) {
+  return mps * MPS_TO_FPS;
+}
+
+/**
+ * Converts acceleration from m/s² to ft/s².
+ * @param {number} mps2 - Value in meters per second squared.
+ * @returns {number} Converted value.
+ */
+export function convertAccelerationToImperial(mps2) {
+  return mps2 * MPS2_TO_FPS2;
+}
+
+/**
+ * Converts pressure from kPa to psi.
+ * @param {number} kpa - Value in Kilopascals.
+ * @returns {number} Converted value.
+ */
+export function convertPressureToImperial(kpa) {
+  return kpa / PSI_TO_KPA;
+}
+
+/**
+ * Converts temperature from Celsius to Fahrenheit
+ * @param {number} celsius - Value in Celsius.
+ * @returns {number} Converted value.
+ */
+export function convertTemperatureToImperial(celsius) {
+  return (celsius * 9 / 5) + 32;
+}
+
+/**
+ * Converts length from feet to meters.
+ * @param {number} feet - Value in feet.
+ * @returns {number} Converted value in meters.
+ */
+export function convertLengthToMetric(feet) {
+  return feet / METERS_TO_FEET;
+}
+
+/**
+ * Converts velocity from ft/s to m/s.
+ * @param {number} fps - Value in feet per second.
+ * @returns {number} Converted value in meters per second.
+ */
+export function convertVelocityToMetric(fps) {
+  return fps / MPS_TO_FPS;
+}
+
+/**
+ * Converts acceleration from ft/s² to m/s².
+ * @param {number} fps2 - Value in feet per second squared.
+ * @returns {number} Converted value in meters per second squared.
+ */
+export function convertAccelerationToMetric(fps2) {
+  return fps2 / MPS2_TO_FPS2;
+}
+
+/**
+ * Converts pressure from psi to kPa.
+ * @param {number} psi - Value in pounds per square inch.
+ * @returns {number} Converted value in Kilopascals.
+ */
+export function convertPressureToMetric(psi) {
+  return psi * PSI_TO_KPA;
+}
+
+/**
+ * Converts temperature from Fahrenheit to Celsius.
+ * @param {number} fahrenheit - Value in Fahrenheit.
+ * @returns {number} Converted value in Celsius.
+ */
+export function convertTemperatureToMetric(fahrenheit) {
+  return (fahrenheit - 32) * 5 / 9;
+}
+
+/**
+ * Formats a raw metric value for display in the target unit system,
+ * including applying specific display unit options and decimal precision.
+ * Assumes rawValue is always in its standard metric (SI) unit.
+ *
+ * @param {number} rawValue - The raw numeric value from the board (always in metric SI base units).
+ * @param {string} paramName - The name of the parameter (e.g., 'altitude', 'acceleration').
+ * @param {string} targetUnitSystem - The desired display unit system ('metric' or 'imperial').
+ * @param {object} [options={}] - Optional display settings.
+ * @param {number} [options.decimals=2] - Number of decimal places for rounding.
+ * @param {boolean} [options.displayInGs=false] - For 'acceleration', display in G-forces.
+ * @param {boolean} [options.displayInBar=false] - For 'pressure', display in Bar.
+ * @param {boolean} [options.displayInKelvin=false] - For 'temperature', display in Kelvin.
+ * @returns {string} The formatted string with value and unit (e.g., "123.45 m", "3.2 g").
+ */
+export function getDisplayValue(rawValue, paramName, targetUnitSystem, options = {}) {
+  // Handle null/undefined values
+  if (rawValue === null || rawValue === undefined) {
+    return '-'; // Or 'N/A' or similar placeholder
+  }
+
+  // Ensure options have defaults
+  const { decimals = 2, excludeLabel = false } = options;
+  const isTargetImperial = targetUnitSystem === 'imperial';
+  let valueToDisplay = parseFloat(rawValue);
+
+  if (isNaN(valueToDisplay)) {
+    return '-';
+  }
+
+  let unitLabel = '';
+
+  switch (paramName) {
+    case 'altitude':
+      valueToDisplay = convertLengthToImperial(rawValue);
+      break;
+    case 'velocity':
+      valueToDisplay = convertVelocityToImperial(rawValue);
+      break;
+    case 'acceleration':
+      valueToDisplay = convertAccelerationToImperial(rawValue);
+      break;
+    case 'pressure':
+      valueToDisplay = convertPressureToImperial(rawValue);
+      break;
+    case 'temperature':
+      valueToDisplay = convertTemperatureToImperial(rawValue);
+      break;
+    default:
+      break;
+  }
+  unitLabel = getUnitLabel(paramName, targetUnitSystem);
+
+  return options.excludeLabel ? `${valueToDisplay.toFixed(decimals)}` : `${valueToDisplay.toFixed(decimals)}${unitLabel}`
+}

--- a/src/views/Config.vue
+++ b/src/views/Config.vue
@@ -3,57 +3,57 @@
     <v-container fluid>
       <v-row>
         <v-col>
-          <v-card v-if="data" height="100%">
+          <v-card v-if="displayData" height="100%">
             <v-card-title>General</v-card-title>
             <v-card-text>
               <v-form ref="form">
-                <v-row v-for="key in Object.keys(data)" :key="key" dense>
-                  <v-col cols="6" v-if="data[key].section === 'general'">
+                <v-row v-for="key in Object.keys(displayData)" :key="key" dense>
+                  <v-col cols="6" v-if="displayData[key].section === 'general'">
                     <div
                       class="text-capitalize py-2"
-                      v-text="data[key].name"
+                      v-text="displayData[key].name"
                     />
                   </v-col>
-                  <v-col cols="6" v-if="data[key].section === 'general'">
+                  <v-col cols="6" v-if="displayData[key].section === 'general'">
                     <v-select
-                      v-if="data[key].type === 'SELECT'"
-                      v-model="data[key].value"
-                      :items="data[key].allowedValues"
+                      v-if="displayData[key].type === 'SELECT'"
+                      v-model="displayData[key].value"
+                      :items="displayData[key].allowedValues"
                       solo
                       dense
                       hide-details
                     ></v-select>
                     <v-text-field
-                      v-if="data[key].type === 'NUMBER'"
-                      v-model.number="data[key].value"
-                      :min="data[key].allowedRange[0]"
-                      :max="data[key].allowedRange[1]"
+                      v-if="displayData[key].type === 'NUMBER'"
+                      v-model.number="displayData[key].value"
+                      :min="displayData[key].allowedRange[0]"
+                      :max="displayData[key].allowedRange[1]"
                       :rules="[
                         (v) =>
-                          (v >= data[key].allowedRange[0] &&
-                            v <= data[key].allowedRange[1]) ||
-                          `Value should be from ${data[key].allowedRange.join(
+                          (v >= displayData[key].allowedRange[0] &&
+                            v <= displayData[key].allowedRange[1]) ||
+                          `Value should be from ${displayData[key].allowedRange.join(
                             ' to '
                           )}`,
                       ]"
-                      :hint="data[key].allowedRange.join(' to ')"
+                      :hint="displayData[key].allowedRange.join(' to ')"
                       type="number"
                       hide-details="auto"
                       solo
                       dense
                     >
                       <template v-slot:append>
-                        {{ data[key].unit }}
+                        {{ displayData[key].unit }}
                       </template>
                     </v-text-field>
                     <v-text-field
-                      v-if="data[key].type === 'STRING'"
-                      v-model="data[key].value"
+                      v-if="displayData[key].type === 'STRING'"
+                      v-model="displayData[key].value"
                       :rules="[
                         (v) => {
-                          if (v.length < data[key].allowedRange[0] ||
-                            v.length > data[key].allowedRange[1]) {
-                            return `String must have length between ${data[key].allowedRange.join(
+                          if (v.length < displayData[key].allowedRange[0] ||
+                            v.length > displayData[key].allowedRange[1]) {
+                            return `String must have length between ${displayData[key].allowedRange.join(
                               ' and '
                             )}`
                           } else if (v.match(/^[_a-z0-9]+$/i) === null) {
@@ -62,14 +62,14 @@
                           return true
                         }
                       ]"
-                      :hint="data[key].allowedRange.join(' to ')"
+                      :hint="displayData[key].allowedRange.join(' to ')"
                       type="text"
                       hide-details="auto"
                       solo
                       dense
                     >
                       <template v-slot:append>
-                        {{ data[key].unit }}
+                        {{ displayData[key].unit }}
                       </template>
                     </v-text-field>
                   </v-col>
@@ -112,12 +112,8 @@
           <v-card v-if="status && status.length" height="100%">
             <v-card-title>Info</v-card-title>
             <v-card-text>
-              <div
-                v-for="item in status"
-                :key="item"
-                class="mb-2"
-                v-text="item"
-              />
+              <div v-for="(item, index) in status.slice(0, 3)" :key="index" class="mb-2" v-text="item"></div>
+              <div v-if="processedStatus && processedStatus.length > 3" class="mb-2" v-text="processedStatus[3]"></div>
             </v-card-text>
           </v-card>
         </v-col>
@@ -128,53 +124,53 @@
             <v-card-title>Telemetry</v-card-title>
             <v-card-text>
               <v-form ref="form">
-                <v-row v-for="key in Object.keys(data)" :key="key" dense>
-                  <v-col cols="6" v-if="data[key].section === 'telemetry'">
+                <v-row v-for="key in Object.keys(displayData)" :key="key" dense>
+                  <v-col cols="6" v-if="displayData[key].section === 'telemetry'">
                     <div
                       class="text-capitalize py-2"
-                      v-text="data[key].name"
+                      v-text="displayData[key].name"
                     />
                   </v-col>
-                  <v-col cols="6" v-if="data[key].section === 'telemetry'">
+                  <v-col cols="6" v-if="displayData[key].section === 'telemetry'">
                     <v-select
-                      v-if="data[key].type === 'SELECT'"
-                      v-model="data[key].value"
-                      :items="data[key].allowedValues"
+                      v-if="displayData[key].type === 'SELECT'"
+                      v-model="displayData[key].value"
+                      :items="displayData[key].allowedValues"
                       solo
                       dense
                       hide-details
                     ></v-select>
                     <v-text-field
-                      v-if="data[key].type === 'NUMBER'"
-                      v-model.number="data[key].value"
-                      :min="data[key].allowedRange[0]"
-                      :max="data[key].allowedRange[1]"
+                      v-if="displayData[key].type === 'NUMBER'"
+                      v-model.number="displayData[key].value"
+                      :min="displayData[key].allowedRange[0]"
+                      :max="displayData[key].allowedRange[1]"
                       :rules="[
                         (v) =>
-                          (v >= data[key].allowedRange[0] &&
-                            v <= data[key].allowedRange[1]) ||
-                          `Value should be from ${data[key].allowedRange.join(
+                          (v >= displayData[key].allowedRange[0] &&
+                            v <= displayData[key].allowedRange[1]) ||
+                          `Value should be from ${displayData[key].allowedRange.join(
                             ' to '
                           )}`,
                       ]"
-                      :hint="data[key].allowedRange.join(' to ')"
+                      :hint="displayData[key].allowedRange.join(' to ')"
                       type="number"
                       hide-details="auto"
                       solo
                       dense
                     >
                       <template v-slot:append>
-                        {{ data[key].unit }}
+                        {{ displayData[key].unit }}
                       </template>
                     </v-text-field>
                     <v-text-field
-                      v-if="data[key].type === 'STRING'"
-                      v-model="data[key].value"
+                      v-if="displayData[key].type === 'STRING'"
+                      v-model="displayData[key].value"
                       :rules="[
                         (v) => {
-                          if (v.length < data[key].allowedRange[0] ||
-                            v.length > data[key].allowedRange[1]) {
-                            return `String must have length between ${data[key].allowedRange.join(
+                          if (v.length < displayData[key].allowedRange[0] ||
+                            v.length > displayData[key].allowedRange[1]) {
+                            return `String must have length between ${displayData[key].allowedRange.join(
                               ' and '
                             )}`
                           } else if (v.match(/^[_a-z0-9]+$/i) === null) {
@@ -183,14 +179,14 @@
                           return true
                         }
                       ]"
-                      :hint="data[key].allowedRange.join(' to ')"
+                      :hint="displayData[key].allowedRange.join(' to ')"
                       type="text"
                       hide-details="auto"
                       solo
                       dense
                     >
                       <template v-slot:append>
-                        {{ data[key].unit }}
+                        {{ displayData[key].unit }}
                       </template>
                     </v-text-field>
                   </v-col>
@@ -204,53 +200,53 @@
             <v-card-title>Testing</v-card-title>
             <v-card-text>
               <v-form ref="form">
-                <v-row v-for="key in Object.keys(data)" :key="key" dense>
-                  <v-col cols="6" v-if="data[key].section === 'testing'">
+                <v-row v-for="key in Object.keys(displayData)" :key="key" dense>
+                  <v-col cols="6" v-if="displayData[key].section === 'testing'">
                     <div
                       class="text-capitalize py-2"
-                      v-text="data[key].name"
+                      v-text="displayData[key].name"
                     />
                   </v-col>
-                  <v-col cols="6" v-if="data[key].section === 'testing'">
+                  <v-col cols="6" v-if="displayData[key].section === 'testing'">
                     <v-select
-                      v-if="data[key].type === 'SELECT'"
-                      v-model="data[key].value"
-                      :items="data[key].allowedValues"
+                      v-if="displayData[key].type === 'SELECT'"
+                      v-model="displayData[key].value"
+                      :items="displayData[key].allowedValues"
                       solo
                       dense
                       hide-details
                     ></v-select>
                     <v-text-field
-                      v-if="data[key].type === 'NUMBER'"
-                      v-model.number="data[key].value"
-                      :min="data[key].allowedRange[0]"
-                      :max="data[key].allowedRange[1]"
+                      v-if="displayData[key].type === 'NUMBER'"
+                      v-model.number="displayData[key].value"
+                      :min="displayData[key].allowedRange[0]"
+                      :max="displayData[key].allowedRange[1]"
                       :rules="[
                         (v) =>
-                          (v >= data[key].allowedRange[0] &&
-                            v <= data[key].allowedRange[1]) ||
-                          `Value should be from ${data[key].allowedRange.join(
+                          (v >= displayData[key].allowedRange[0] &&
+                            v <= displayData[key].allowedRange[1]) ||
+                          `Value should be from ${displayData[key].allowedRange.join(
                             ' to '
                           )}`,
                       ]"
-                      :hint="data[key].allowedRange.join(' to ')"
+                      :hint="displayData[key].allowedRange.join(' to ')"
                       type="number"
                       hide-details="auto"
                       solo
                       dense
                     >
                       <template v-slot:append>
-                        {{ data[key].unit }}
+                        {{ displayData[key].unit }}
                       </template>
                     </v-text-field>
                     <v-text-field
-                      v-if="data[key].type === 'STRING'"
-                      v-model="data[key].value"
+                      v-if="displayData[key].type === 'STRING'"
+                      v-model="displayData[key].value"
                       :rules="[
                         (v) => {
-                          if (v.length < data[key].allowedRange[0] ||
-                            v.length > data[key].allowedRange[1]) {
-                            return `String must have length between ${data[key].allowedRange.join(
+                          if (v.length < displayData[key].allowedRange[0] ||
+                            v.length > displayData[key].allowedRange[1]) {
+                            return `String must have length between ${displayData[key].allowedRange.join(
                               ' and '
                             )}`
                           } else if (v.match(/^[_a-z0-9]+$/i) === null) {
@@ -259,14 +255,14 @@
                           return true
                         }
                       ]"
-                      :hint="data[key].allowedRange.join(' to ')"
+                      :hint="displayData[key].allowedRange.join(' to ')"
                       type="text"
                       hide-details="auto"
                       solo
                       dense
                     >
                       <template v-slot:append>
-                        {{ data[key].unit }}
+                        {{ displayData[key].unit }}
                       </template>
                     </v-text-field>
                   </v-col>
@@ -285,6 +281,64 @@
 import { mapState, mapActions } from "vuex";
 import { getConfigs, setConfigs } from "@/services/configService";
 import ActionsBar from "@/components/ActionsBar";
+import { getDisplayValue } from "@/utils/unitConversions";
+import { convertLengthToImperial, convertAccelerationToImperial, convertLengthToMetric, convertAccelerationToMetric } from "../utils/unitConversions";
+
+function convertMetricDataToImperial(data) {
+  const imperialData = structuredClone(data);
+      
+  imperialData["main_altitude"].value = Math.round(convertLengthToImperial(
+    data["main_altitude"].value
+  ));
+  imperialData["main_altitude"].allowedRange[0] = Math.round(convertLengthToImperial(
+    data["main_altitude"].allowedRange[0]
+  ));
+  imperialData["main_altitude"].allowedRange[1] = Math.round(convertLengthToImperial(
+    data["main_altitude"].allowedRange[1]
+  ));
+  imperialData["main_altitude"].unit = "ft";
+
+  imperialData["acc_threshold"].value = Math.round(convertAccelerationToImperial(
+    data["acc_threshold"].value
+  ));
+  imperialData["acc_threshold"].allowedRange[0] = Math.round(convertAccelerationToImperial(
+    data["acc_threshold"].allowedRange[0]
+  ));
+  imperialData["acc_threshold"].allowedRange[1] = Math.round(convertAccelerationToImperial(
+    data["acc_threshold"].allowedRange[1]
+  ));
+  imperialData["acc_threshold"].unit = "ft/s²";
+
+  return imperialData;
+}
+
+function convertImperialDataToMetric(data) {
+  const metricData = structuredClone(data);
+
+  metricData["main_altitude"].value = Math.round(convertLengthToMetric(
+    data["main_altitude"].value
+  ));
+  metricData["main_altitude"].allowedRange[0] = Math.round(convertLengthToMetric(
+    data["main_altitude"].allowedRange[0]
+  ));
+  metricData["main_altitude"].allowedRange[1] = Math.round(convertLengthToMetric(
+    data["main_altitude"].allowedRange[1]
+  ));
+  metricData["main_altitude"].unit = "m";
+
+  metricData["acc_threshold"].value = Math.round(convertAccelerationToMetric(
+    data["acc_threshold"].value
+  ));
+  metricData["acc_threshold"].allowedRange[0] = Math.round(convertAccelerationToMetric(
+    data["acc_threshold"].allowedRange[0]
+  ));
+  metricData["acc_threshold"].allowedRange[1] = Math.round(convertAccelerationToMetric(
+    data["acc_threshold"].allowedRange[1]
+  ));
+  metricData["acc_threshold"].unit = "m/s²";
+
+  return metricData;
+}
 
 export default {
   name: "ConfigView",
@@ -297,6 +351,7 @@ export default {
       backupLoading: false,
       restoreLoading: false,
       data: {},
+      imperialData: {}
     };
   },
   watch: {
@@ -317,16 +372,35 @@ export default {
       deep: true,
       immediate: true,
     },
+    useImperialUnits(newValue) {
+      if (!newValue) return;
+      this.imperialData = convertMetricDataToImperial(structuredClone(this.data));
+    }
   },
   computed: {
     ...mapState({
       config: (state) => state.config,
       status: (state) => state.static.status,
       changedTab: (state) => state.changedTab,
+      useImperialUnits: (state) => state.useImperialUnits
     }),
     changed() {
       return this.changedTab === "config";
     },
+    processedStatus() {
+      if (!this.status || !Array.isArray(this.status)) {
+        return [];
+      }
+      return this.status.map((line, index) => {
+        if (index === 3 && this.useImperialUnits) {
+          return this.convertStatusLine4(line);
+        }
+        return line;
+      });
+    },
+    displayData() {
+      return this.useImperialUnits ? this.imperialData : this.data;
+    }
   },
   mounted() {
     this.init();
@@ -340,6 +414,9 @@ export default {
         clearInterval(this.timer);
       }
     });
+    if (this.useImperialUnits) {
+      this.imperialData = convertMetricDataToImperial(structuredClone(this.data));
+    }
   },
 
   beforeDestroy() {
@@ -361,7 +438,12 @@ export default {
     onSave() {
       if (!this.$refs.form.validate()) return;
 
-      setConfigs(this.data);
+      if (this.useImperialUnits) {
+        setConfigs(convertImperialDataToMetric(structuredClone(this.displayData)));
+      } else {
+        setConfigs(this.displayData);
+      }
+
       getConfigs();
     },
     backupConfig() {
@@ -388,6 +470,25 @@ export default {
         this.init();
       }
     },
+    convertStatusLine4(statusLine) {
+      const regex = /h:\s*(-?\d*\.?\d+)\s*m,\s*v:\s*(-?\d*\.?\d+)\s*m\/s,\s*a:\s*(-?\d*\.?\d+)\s*m\/s\^2/;
+      const match = statusLine.match(regex);
+
+      if (match) {
+        const rawAltitude = parseFloat(match[1]);
+        const rawVelocity = parseFloat(match[2]);
+        const rawAcceleration = parseFloat(match[3]);
+
+        const displayAltitude = getDisplayValue(rawAltitude, 'altitude', 'imperial');
+        const displayVelocity = getDisplayValue(rawVelocity, 'velocity', 'imperial');
+        const displayAcceleration = getDisplayValue(rawAcceleration, 'acceleration', 'imperial');
+
+        return `h: ${displayAltitude}, v: ${displayVelocity}, a: ${displayAcceleration}`;
+      } else {
+        console.warn("Could not parse status line for conversion:", statusLine);
+        return statusLine;
+      }
+    }
   },
 };
 </script>

--- a/src/views/Config.vue
+++ b/src/views/Config.vue
@@ -479,9 +479,9 @@ export default {
         const rawVelocity = parseFloat(match[2]);
         const rawAcceleration = parseFloat(match[3]);
 
-        const displayAltitude = getDisplayValue(rawAltitude, 'altitude', 'imperial');
-        const displayVelocity = getDisplayValue(rawVelocity, 'velocity', 'imperial');
-        const displayAcceleration = getDisplayValue(rawAcceleration, 'acceleration', 'imperial');
+        const displayAltitude = getDisplayValue(rawAltitude, 'altitude', {targetUnitSystem: 'imperial', numeric: false});
+        const displayVelocity = getDisplayValue(rawVelocity, 'velocity', {targetUnitSystem: 'imperial', numeric: false});
+        const displayAcceleration = getDisplayValue(rawAcceleration, 'acceleration', {targetUnitSystem: 'imperial', numeric: false});
 
         return `h: ${displayAltitude}, v: ${displayVelocity}, a: ${displayAcceleration}`;
       } else {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -148,5 +148,13 @@ export default {
       }
     }
   },
+  watch: {
+    useImperialUnits(newValue) {
+      if (this.flightLog) {
+        this.$refs.flightLogPlotContainer.innerHTML = "";
+        this.replot();
+      }
+    }
+  }
 };
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -69,6 +69,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
 import { makePlots } from '../modules/plots'
 
 export default {
@@ -85,6 +86,9 @@ export default {
       fileLoading: false,
     };
   },
+  computed: {
+    ...mapState(['useImperialUnits']),
+  },
   mounted() {
     window.renderer.on("LOAD_FLIGHTLOG", (flightLog) => {
       this.fileLoading = false
@@ -99,7 +103,7 @@ export default {
       this.errorString = "";
       this.flightLog = flightLog;
 
-      if (el) makePlots(flightLog, el)
+      if (el) makePlots(flightLog, el, this.useImperialUnits);
     });
     window.renderer.on("EXPORT_FLIGHTLOG_CSVS", (flightLog) => {
       this.exportButtonLoading = false;
@@ -132,7 +136,7 @@ export default {
     replot() {
       let el = this.$refs.flightLogPlotContainer
       if (el && this.flightLog) {
-        makePlots(this.flightLog, el)
+        makePlots(this.flightLog, el, this.useImperialUnits);
       }
     },
     onDrop(event) {


### PR DESCRIPTION
We're adding a toggle in the lower left of the UI that allows users to switch the unit system used by the app. It affects the following:

### Configuration screen
Main Altitude, Liftoff Detection Acceleration in the general section and the fourth line in the Info section.

### Home screen
Certain charts are affected, see the following list for details. When the unit is changed they will re-render.

- Altitude in the first chart
- Velocity in the second chart
- Acceleration in the third chart
- Temperature in the fifth chart
- Altitude in the sixth chart

Close #25 
