### PR TITLE
Avoid duplicate CI runs for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: CI and release
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - "*"
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Summary

- run branch-push CI only for `main`
- preserve push-triggered release workflows for all tags
- retain normal `pull_request` validation for review branches
- prevent PR commits from launching duplicate quality and packaging matrices

This PR is intentionally stacked on `configurator-update` because that is where PR #42 introduces the combined `push` and `pull_request` workflow.

## Verification

- Prettier workflow formatting check passed
- workflow YAML parsed successfully
- `main`, tag, and pull-request trigger behavior was asserted locally