### PR TITLE
Separate telemetry values from unit labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 11-08-2026
+
+- Separate formatted telemetry values from their unit labels for clearer status
+  readouts and exported plots.
+
 ## [1.3.0] - 10-08-2026
 
 - Check GitHub automatically for newer stable CATS Configurator releases and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cats-configurator",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cats-configurator",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "plotly.js-dist-min": "^3.7.0",
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cats-configurator",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Desktop configuration and flight-log analysis utility for CATS flight computers.",
   "author": "CATS Systems",
   "private": true,

--- a/src/utils/unitConversions.js
+++ b/src/utils/unitConversions.js
@@ -204,5 +204,5 @@ export function getDisplayValue(rawValue, paramName, options = {}) {
 
   return excludeLabel
     ? `${convertedValue.toFixed(decimals)}`
-    : `${convertedValue.toFixed(decimals)}${unitLabel}`;
+    : `${convertedValue.toFixed(decimals)} ${unitLabel}`;
 }

--- a/templates/plots.html
+++ b/templates/plots.html
@@ -140,7 +140,7 @@
 
         if (numeric) return convertedValue;
 
-        return excludeLabel ? `${convertedValue.toFixed(decimals)}` : `${convertedValue.toFixed(decimals)}${unitLabel}`
+        return excludeLabel ? `${convertedValue.toFixed(decimals)}` : `${convertedValue.toFixed(decimals)} ${unitLabel}`
       }
 
 

--- a/tests/e2e/electron.spec.js
+++ b/tests/e2e/electron.spec.js
@@ -71,7 +71,7 @@ test("launches the packaged renderer and exercises the secure bridge", async ({}
       });
     await expect(page).toHaveTitle("CATS Configurator");
     await expect(page.getByText("Status: Disconnected")).toBeVisible();
-    await expect(page.getByText("App version: 1.3.0")).toBeVisible();
+    await expect(page.getByText("App version: 1.3.1")).toBeVisible();
     await expect(page.getByText("CATS", { exact: true })).toBeVisible();
     await expect(page.getByText("Configurator", { exact: true })).toBeVisible();
     await expect(

--- a/tests/unit/components.test.js
+++ b/tests/unit/components.test.js
@@ -20,7 +20,7 @@ describe("renderer state components", () => {
   beforeEach(() => {
     pinia = createPinia();
     setActivePinia(pinia);
-    globalThis.__APP_VERSION__ = "1.3.0";
+    globalThis.__APP_VERSION__ = "1.3.1";
     window.cats = {
       updates: {
         check: vi.fn(),

--- a/tests/unit/unit-conversions.test.js
+++ b/tests/unit/unit-conversions.test.js
@@ -20,7 +20,19 @@ describe("unit conversions", () => {
   it("formats converted values with their unit", () => {
     expect(
       getDisplayValue(100, "altitude", { numeric: false, decimals: 1 }),
-    ).toBe("328.1ft");
+    ).toBe("328.1 ft");
+    expect(
+      getDisplayValue(9.81, "acceleration", {
+        numeric: false,
+        decimals: 1,
+      }),
+    ).toBe("32.2 ft/s²");
+    expect(
+      getDisplayValue(20, "temperature", {
+        numeric: false,
+        decimals: 0,
+      }),
+    ).toBe("68 °F");
     expect(getDisplayValue(undefined, "altitude")).toBe("-");
   });
 });

--- a/tests/visual/compare-releases.mjs
+++ b/tests/visual/compare-releases.mjs
@@ -340,7 +340,7 @@ async function captureRelease(label, executablePath, useSource = false) {
       path: path.join(outputDirectory, "home-flight-log-plot.png"),
     });
 
-    if (label === "1.3.0" && runtimeErrors.length) {
+    if (label === "1.3.1" && runtimeErrors.length) {
       throw new Error(
         `${label} emitted runtime errors:\n${runtimeErrors.join("\n")}`,
       );
@@ -355,4 +355,4 @@ async function captureRelease(label, executablePath, useSource = false) {
 }
 
 await captureRelease("0.3.10", referenceExecutable);
-await captureRelease("1.3.0", candidateExecutable, candidateUsesSource);
+await captureRelease("1.3.1", candidateExecutable, candidateUsesSource);


### PR DESCRIPTION
## Summary

- add readable spacing between formatted telemetry values and their unit labels
- keep the renderer and standalone flight-log plot template consistent
- add regression coverage for altitude, acceleration, and temperature formatting
- bump the patch release and release expectations to 1.3.1

## Verification

- 61 unit and component tests pass
- ESLint passes
- Prettier check passes
- production build passes
- production-target and release-contract checks pass
- the `1.3.1` release-tag contract passes

The local Windows Electron smoke target crashed before assertions in the sandbox; the same smoke suite remains enabled in GitHub CI.

## Release follow-up

After this PR is merged, create tag `1.3.1` on the resulting `main` commit and push that tag. The tag push starts the production packaging/release workflow used to validate the automatic upgrade path.