### PR TITLE
Use a GitHub-safe Windows installer name

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "npmRebuild": false,
     "win": {
       "icon": "build/icon.ico",
-      "artifactName": "${name} Setup ${version}.${ext}",
+      "artifactName": "${name}-Setup-${version}.${ext}",
       "target": [
         "nsis"
       ]

--- a/src/modules/update-manager.js
+++ b/src/modules/update-manager.js
@@ -42,7 +42,8 @@ function normalizeStableVersion(tagName) {
 
 export function expectedUpdateAssetName(platform, arch, version) {
   if (platform === "win32" && arch === "x64") {
-    return `cats-configurator Setup ${version}.exe`;
+    // GitHub normalizes spaces in uploaded asset filenames, so keep this URL-safe.
+    return `cats-configurator-Setup-${version}.exe`;
   }
   if (platform === "darwin" && ["x64", "arm64"].includes(arch)) {
     return `cats-configurator-${version}-${arch}.dmg`;

--- a/tests/unit/components.test.js
+++ b/tests/unit/components.test.js
@@ -96,7 +96,7 @@ describe("renderer state components", () => {
     store.setUpdateState({
       status: "ready",
       availableVersion: "1.4.0",
-      assetName: "cats-configurator Setup 1.4.0.exe",
+      assetName: "cats-configurator-Setup-1.4.0.exe",
       message: "Ready",
     });
     await nextTick();

--- a/tests/unit/update-manager.test.js
+++ b/tests/unit/update-manager.test.js
@@ -114,7 +114,7 @@ afterEach(async () => {
 describe("update release validation", () => {
   it("locks the supported platform asset names", () => {
     expect(expectedUpdateAssetName("win32", "x64", "1.4.0")).toBe(
-      "cats-configurator Setup 1.4.0.exe",
+      "cats-configurator-Setup-1.4.0.exe",
     );
     expect(expectedUpdateAssetName("darwin", "x64", "1.4.0")).toBe(
       "cats-configurator-1.4.0-x64.dmg",

--- a/tests/verify-packaged-artifact.mjs
+++ b/tests/verify-packaged-artifact.mjs
@@ -5,7 +5,7 @@ import packageJson from "../package.json" with { type: "json" };
 
 function expectedUpdateAssetName(platform, arch, version) {
   if (platform === "win32" && arch === "x64") {
-    return `cats-configurator Setup ${version}.exe`;
+    return `cats-configurator-Setup-${version}.exe`;
   }
   if (platform === "darwin" && ["x64", "arm64"].includes(arch)) {
     return `cats-configurator-${version}-${arch}.dmg`;

--- a/tests/verify-release-contract.mjs
+++ b/tests/verify-release-contract.mjs
@@ -17,7 +17,7 @@ assert.equal(
 );
 assert.equal(
   packageJson.build.win.artifactName,
-  "${name} Setup ${version}.${ext}",
+  "${name}-Setup-${version}.${ext}",
   "Windows release name no longer matches the updater contract",
 );
 assert.equal(


### PR DESCRIPTION
## Summary

- rename the Windows installer contract to use hyphens instead of spaces
- keep electron-builder output, updater selection, and release verification aligned
- update component and updater fixtures for the GitHub-safe asset name

## Why

GitHub normalizes spaces in uploaded release asset filenames. The 1.3.1 release therefore exposes the Windows asset name with dots through the Releases API, while the updater requires the original space-containing name and falls back to manual download.

Existing builds with the old hardcoded contract still require one manual upgrade. Releases built from this change will use a stable filename that future updaters can discover and verify.

## Verification

- 61 unit and component tests passed
- ESLint passed
- Prettier check passed
- release artifact contract check passed
- full Windows x64 NSIS package build passed
- packaged artifact verified as cats-configurator-Setup-1.3.1.exe