### PR TITLE
Set the package version to 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 11-08-2026
+
+- Use a GitHub-safe Windows installer filename so the automatic updater can
+  discover and verify the release asset.
+
 ## [1.3.1] - 11-08-2026
 
 - Separate formatted telemetry values from their unit labels for clearer status

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cats-configurator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cats-configurator",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "plotly.js-dist-min": "^3.7.0",
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cats-configurator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Desktop configuration and flight-log analysis utility for CATS flight computers.",
   "author": "CATS Systems",
   "private": true,

--- a/tests/e2e/electron.spec.js
+++ b/tests/e2e/electron.spec.js
@@ -71,7 +71,7 @@ test("launches the packaged renderer and exercises the secure bridge", async ({}
       });
     await expect(page).toHaveTitle("CATS Configurator");
     await expect(page.getByText("Status: Disconnected")).toBeVisible();
-    await expect(page.getByText("App version: 1.3.1")).toBeVisible();
+    await expect(page.getByText("App version: 1.3.2")).toBeVisible();
     await expect(page.getByText("CATS", { exact: true })).toBeVisible();
     await expect(page.getByText("Configurator", { exact: true })).toBeVisible();
     await expect(


### PR DESCRIPTION
## Summary

- set package and lockfile metadata to 1.3.2
- document the GitHub-safe Windows installer fix in the changelog

## Why

The existing 1.3.2 tag points to a commit that still declares package version 1.3.1. The release-version gate correctly stopped packaging, leaving the release without native installers.

## Verification

- 61 unit and component tests passed
- ESLint passed
- Prettier passed
- release artifact contract passed
- release tag 1.3.2 matches package version