### PR TITLE
Prepare Windows releases for SignPath signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,8 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           name: CATS Configurator ${{ github.ref_name }}
+          body: |
+            [Code signing policy](https://github.com/catsystems/cats-configurator/blob/main/CODE_SIGNING_POLICY.md)
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: release-artifacts/*

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,75 @@
+# Code signing policy
+
+Official CATS Configurator releases are built from the public source code and
+build configuration in this repository under the
+[GNU General Public License v3](LICENSE). Free code signing provided by
+[SignPath.io](https://signpath.io/), certificate by
+[SignPath Foundation](https://signpath.org/).
+
+## Signed releases
+
+- Signing is limited to official CATS Configurator release artifacts produced
+  by the repository's GitHub Actions workflow from a version tag.
+- SignPath signing under this policy applies to the official Windows NSIS
+  installer. The macOS and Linux packages use their platform-specific release
+  processes and are not signed by the SignPath Foundation certificate.
+- Every signing request requires manual approval by a designated approver.
+- The signed Windows installer is published through the repository's
+  [GitHub Releases](https://github.com/catsystems/cats-configurator/releases).
+- Signatures do not apply to forks, local builds, or binaries redistributed by
+  third parties.
+
+## Team roles
+
+- Authors and committers:
+  [Nemanja Stojoski (@stojadin2701)](https://github.com/stojadin2701)
+- Reviewers:
+  [Nemanja Stojoski (@stojadin2701)](https://github.com/stojadin2701)
+- Signing approvers:
+  [Nemanja Stojoski (@stojadin2701)](https://github.com/stojadin2701)
+- Contributions from people who do not have commit access are reviewed before
+  they are merged.
+- Additional people will be listed here before they receive a signing role.
+- Everyone with repository write access or a SignPath signing role must enable
+  multi-factor authentication for both GitHub and SignPath.
+
+## Privacy policy
+
+CATS Configurator does not include analytics, advertising, user tracking, or
+crash-reporting services. Device configuration, application settings, and
+flight-log processing are performed locally unless the user explicitly opens
+an external service.
+
+Packaged versions automatically query the GitHub Releases API shortly after
+startup and every six hours to check for updates. When a newer stable release
+is available, the application downloads the matching release artifact from
+GitHub into its local update cache, verifies its size and GitHub-provided
+SHA-256 digest, and asks the user before installation. The application never
+executes a downloaded installer automatically. These requests are governed by
+the [GitHub General Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement).
+
+External documentation, release pages, and CATS Flights are opened only after
+a user action. Choosing to analyze a flight log with CATS Flights opens
+`https://flights.catsystems.io` in the user's browser and makes the selected
+log available to that browser through a temporary loopback-only connection.
+
+The application does not otherwise transfer user files, device configuration,
+flight logs, or serial data to networked systems.
+
+## Installation and system changes
+
+The Windows NSIS installer installs CATS Configurator, registers it in the
+Windows installed-apps list, and provides an uninstaller. It does not install
+drivers or browser extensions and does not change security settings.
+
+To uninstall:
+
+- Windows: open **Settings > Apps > Installed apps**, select **CATS
+  Configurator**, and choose **Uninstall**.
+- macOS: quit CATS Configurator and move it from **Applications** to the Trash.
+- Linux AppImage: quit CATS Configurator and delete the AppImage file and any
+  launcher entry created by the user.
+
+Application settings and downloaded-update files are stored in the operating
+system's per-user application-data directory. Users may remove that directory
+separately if they also want to delete their local settings and update cache.

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -22,11 +22,17 @@ build configuration in this repository under the
 ## Team roles
 
 - Authors and committers:
-  [Nemanja Stojoski (@stojadin2701)](https://github.com/stojadin2701)
+  [Nemanja Stojoski (@stojadin2701)](https://github.com/stojadin2701),
+  [Luca Jost (@l-jost)](https://github.com/l-jost), and
+  [Jonas Binz (@jbinz)](https://github.com/jbinz)
 - Reviewers:
-  [Nemanja Stojoski (@stojadin2701)](https://github.com/stojadin2701)
+  [Nemanja Stojoski (@stojadin2701)](https://github.com/stojadin2701),
+  [Luca Jost (@l-jost)](https://github.com/l-jost), and
+  [Jonas Binz (@jbinz)](https://github.com/jbinz)
 - Signing approvers:
-  [Nemanja Stojoski (@stojadin2701)](https://github.com/stojadin2701)
+  [Nemanja Stojoski (@stojadin2701)](https://github.com/stojadin2701),
+  [Luca Jost (@l-jost)](https://github.com/l-jost), and
+  [Jonas Binz (@jbinz)](https://github.com/jbinz)
 - Contributions from people who do not have commit access are reviewed before
   they are merged.
 - Additional people will be listed here before they receive a signing role.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ CI installs exclusively from `package-lock.json`, runs lint, formatting, tests,
 and security gates, then packages each platform. Tags publish the four native
 artifacts as one GitHub release.
 
+See the [Code signing policy](CODE_SIGNING_POLICY.md) for release provenance,
+maintainer roles, privacy information, and uninstall instructions.
+
 ## Open source
 
-All CATS code is open source and can be used free of charge without warranty.
+CATS Configurator is licensed under the
+[GNU General Public License v3](LICENSE) and can be used free of charge without
+warranty.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "CATS Configurator",
   "version": "1.3.2",
   "description": "Desktop configuration and flight-log analysis utility for CATS flight computers.",
-  "author": "CATS Systems",
+  "author": "Control and Telemetry Systems GmbH",
   "private": true,
   "main": "out/main/background.js",
   "scripts": {
@@ -62,7 +62,7 @@
   },
   "build": {
     "appId": "com.cats.cats-configurator",
-    "copyright": "Copyright © 2026 CATS Systems",
+    "copyright": "Copyright © 2026 Control and Telemetry Systems GmbH",
     "directories": {
       "buildResources": "build",
       "output": "builds"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cats-configurator",
+  "productName": "CATS Configurator",
   "version": "1.3.2",
   "description": "Desktop configuration and flight-log analysis utility for CATS flight computers.",
   "author": "CATS Systems",
@@ -61,6 +62,7 @@
   },
   "build": {
     "appId": "com.cats.cats-configurator",
+    "copyright": "Copyright © 2026 CATS Systems",
     "directories": {
       "buildResources": "build",
       "output": "builds"
@@ -72,6 +74,7 @@
     "npmRebuild": false,
     "win": {
       "icon": "build/icon.ico",
+      "executableName": "CATS Configurator",
       "artifactName": "${name}-Setup-${version}.${ext}",
       "target": [
         "nsis"

--- a/tests/verify-release-contract.mjs
+++ b/tests/verify-release-contract.mjs
@@ -22,12 +22,12 @@ assert.equal(
 );
 assert.equal(
   packageJson.author,
-  "CATS Systems",
+  "Control and Telemetry Systems GmbH",
   "company name no longer matches the signing metadata contract",
 );
 assert.equal(
   packageJson.build.copyright,
-  "Copyright © 2026 CATS Systems",
+  "Copyright © 2026 Control and Telemetry Systems GmbH",
   "copyright no longer matches the signing metadata contract",
 );
 assert.equal(

--- a/tests/verify-release-contract.mjs
+++ b/tests/verify-release-contract.mjs
@@ -16,6 +16,26 @@ assert.equal(
   "root lockfile metadata must match the package version",
 );
 assert.equal(
+  packageJson.productName,
+  "CATS Configurator",
+  "product name no longer matches the signing metadata contract",
+);
+assert.equal(
+  packageJson.author,
+  "CATS Systems",
+  "company name no longer matches the signing metadata contract",
+);
+assert.equal(
+  packageJson.build.copyright,
+  "Copyright © 2026 CATS Systems",
+  "copyright no longer matches the signing metadata contract",
+);
+assert.equal(
+  packageJson.build.win.executableName,
+  "CATS Configurator",
+  "Windows executable name no longer matches the signing metadata contract",
+);
+assert.equal(
   packageJson.build.win.artifactName,
   "${name}-Setup-${version}.${ext}",
   "Windows release name no longer matches the updater contract",
@@ -46,6 +66,10 @@ for (const expected of [
 assert.ok(
   workflow.includes("npm run verify:release-tag"),
   "release workflow does not validate the tag against the package version",
+);
+assert.ok(
+  workflow.includes("CODE_SIGNING_POLICY.md"),
+  "generated release notes do not link to the code signing policy",
 );
 
 console.log("Release artifact naming and architecture contract verified.");


### PR DESCRIPTION
## Summary

- add the SignPath-required code signing policy, including release scope, team roles, MFA expectations, privacy disclosures, system changes, and uninstall instructions
- link the policy from the README and prepend it to generated GitHub release notes
- make Windows product, executable, company, copyright, and version metadata deterministic and protect the configuration with release-contract assertions

This PR does not add SignPath credentials or submit signing requests.

## Verification

- Prettier check
- ESLint
- 61 unit and component tests
- release artifact contract
- electron-builder configuration validation
- GitHub Actions workflow YAML parsing
- full Windows x64 NSIS build
- generated installer metadata inspection: CATS Configurator 1.3.2, CATS Systems, expected copyright, unsigned as expected
- packaged Windows artifact verification