### PR TITLE
Refresh delayed telemetry version in the footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cats-configurator",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cats-configurator",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "plotly.js-dist-min": "^3.7.0",
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cats-configurator",
   "productName": "CATS Configurator",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Desktop configuration and flight-log analysis utility for CATS flight computers.",
   "author": "Control and Telemetry Systems GmbH",
   "private": true,

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -79,6 +79,7 @@ export default {
 }
 
 .update-footer__version {
+  font-size: inherit;
   min-width: 0;
   padding-inline: 4px;
   text-transform: none;

--- a/src/modules/serial.js
+++ b/src/modules/serial.js
@@ -24,11 +24,13 @@ import { assertBoardEntries, IPC_CHANNELS } from "../shared/ipc.js";
 
 const CONFIG = { baudRate: 115200 };
 const BOARD_IDENTIFICATION_TIMEOUT_MS = 5000;
+const TELEMETRY_VERSION_REFRESH_DELAY_MS = 5000;
 
 let mainWindow;
 let port;
 let parser;
 let commandEngine;
+let telemetryVersionRefreshTimer;
 let currentNotification;
 let communicationLogStream;
 
@@ -297,6 +299,35 @@ function setSerialWindow(window) {
   mainWindow = window;
 }
 
+function clearTelemetryVersionRefresh() {
+  clearTimeout(telemetryVersionRefreshTimer);
+  telemetryVersionRefreshTimer = undefined;
+}
+
+function scheduleTelemetryVersionRefresh(output) {
+  clearTelemetryVersionRefresh();
+  if (parseBoardIdentity(output).telemetryFirmwareVersion) return;
+
+  const engine = commandEngine;
+  telemetryVersionRefreshTimer = setTimeout(() => {
+    telemetryVersionRefreshTimer = undefined;
+    if (commandEngine !== engine) return;
+
+    void engine
+      .run("version", { retries: 0 })
+      .then((response) => {
+        if (commandEngine !== engine) return;
+        sendToRenderer(
+          IPC_CHANNELS.BOARD_STATIC_DATA,
+          parseData("version", response.output.join("\n")),
+        );
+      })
+      .catch(() => {
+        // The board was already identified, so a failed refresh is non-fatal.
+      });
+  }, TELEMETRY_VERSION_REFRESH_DELAY_MS);
+}
+
 async function getList() {
   if (useFakeSerial) {
     if (Date.now() - fakeSerialStartedAt < fakeSerialAppearAfterMs) return [];
@@ -318,6 +349,7 @@ async function getList() {
 
 function connect(serialPath) {
   if (useFakeSerial) {
+    clearTelemetryVersionRefresh();
     startCommunicationLog(serialPath);
     commandEngine?.cancel("Board connection replaced.");
     commandEngine = createCommandEngine(feedFakeCommand);
@@ -340,6 +372,7 @@ function connect(serialPath) {
     return;
   }
 
+  clearTelemetryVersionRefresh();
   startCommunicationLog(serialPath);
 
   const candidatePort = new SerialPort(
@@ -347,6 +380,7 @@ function connect(serialPath) {
     (error) => {
       if (!error) return;
       if (port === candidatePort) port = null;
+      clearTelemetryVersionRefresh();
       commandEngine?.cancel(error);
       commandEngine = null;
       writeCommunicationLog("ERROR", error.message);
@@ -384,6 +418,7 @@ function connect(serialPath) {
   });
   candidatePort.on("close", () => {
     if (port === candidatePort) port = null;
+    clearTelemetryVersionRefresh();
     parser = null;
     commandEngine?.cancel();
     commandEngine = null;
@@ -412,6 +447,7 @@ async function identifyBoard() {
       body: response.output.join("\n"),
     });
     sendToRenderer(IPC_CHANNELS.BOARD_ACTIVE, true);
+    scheduleTelemetryVersionRefresh(response.output);
   } catch (error) {
     const message =
       error instanceof BoardCommandError && /timed out/i.test(error.message)
@@ -424,6 +460,7 @@ async function identifyBoard() {
 
 function disconnect() {
   writeCommunicationLog("SESSION", "Disconnect requested");
+  clearTelemetryVersionRefresh();
   commandEngine?.cancel();
   if (useFakeSerial) {
     commandEngine = null;

--- a/tests/e2e/electron.spec.js
+++ b/tests/e2e/electron.spec.js
@@ -70,8 +70,19 @@ test("launches the packaged renderer and exercises the secure bridge", async ({}
         title: "CATS Configurator",
       });
     await expect(page).toHaveTitle("CATS Configurator");
-    await expect(page.getByText("Status: Disconnected")).toBeVisible();
-    await expect(page.getByText("App version: 1.4.0")).toBeVisible();
+    const statusLabel = page.getByText("Status: Disconnected");
+    const appVersionButton = page.getByRole("button", {
+      name: "Check for updates",
+    });
+    await expect(statusLabel).toBeVisible();
+    await expect(appVersionButton).toContainText("App version: 1.4.1");
+    const [statusFontSize, appVersionFontSize] = await Promise.all([
+      statusLabel.evaluate((element) => getComputedStyle(element).fontSize),
+      appVersionButton.evaluate(
+        (element) => getComputedStyle(element).fontSize,
+      ),
+    ]);
+    expect(appVersionFontSize).toBe(statusFontSize);
     await expect(page.getByText("CATS", { exact: true })).toBeVisible();
     await expect(page.getByText("Configurator", { exact: true })).toBeVisible();
     await expect(

--- a/tests/unit/serial.test.js
+++ b/tests/unit/serial.test.js
@@ -116,9 +116,16 @@ describe("serial board identification", () => {
     return [`${key} = 0`, "Allowed range: 0 - 4294967295"];
   }
 
-  async function identify(port) {
+  async function identify(
+    port,
+    output = [
+      "Board: CATS Vega",
+      "Firmware: test",
+      "Telemetry Code version: 1.1.3",
+    ],
+  ) {
     port.openSuccessfully();
-    respond("version", ["Board: CATS Vega", "Firmware: test"]);
+    respond("version", output);
     await vi.waitFor(() =>
       expect(sent).toContainEqual([IPC_CHANNELS.BOARD_ACTIVE, true]),
     );
@@ -148,6 +155,9 @@ describe("serial board identification", () => {
 
     expect(sent).toContainEqual([IPC_CHANNELS.BOARD_ACTIVE, true]);
     expect(
+      port.write.mock.calls.filter(([command]) => command === "version\n"),
+    ).toHaveLength(1);
+    expect(
       sent.some(
         ([channel, message]) =>
           channel === IPC_CHANNELS.SERIAL_ERROR &&
@@ -156,6 +166,50 @@ describe("serial board identification", () => {
     ).toBe(false);
     expect(port.isOpen).toBe(true);
     serial.disconnect();
+  });
+
+  it("refreshes a telemetry version that was unavailable during identification", async () => {
+    serial.connect("COM4");
+    const port = serialState.instances[0];
+    await identify(port, [
+      "Board: CATS Vega",
+      "Code version: 3.0.2-dev",
+      "Telemetry Code version:",
+    ]);
+
+    expect(
+      port.write.mock.calls.filter(([command]) => command === "version\n"),
+    ).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.waitFor(() =>
+      expect(
+        port.write.mock.calls.filter(([command]) => command === "version\n"),
+      ).toHaveLength(2),
+    );
+    respond("version", [
+      "Board: CATS Vega",
+      "Code version: 3.0.2-dev",
+      "Telemetry Code version: 1.1.3",
+    ]);
+
+    await vi.waitFor(() =>
+      expect(sent).toContainEqual([
+        IPC_CHANNELS.BOARD_STATIC_DATA,
+        {
+          key: "version",
+          value: [
+            "Board: CATS Vega",
+            "Code version: 3.0.2-dev",
+            "Telemetry Code version: 1.1.3",
+          ],
+        },
+      ]),
+    );
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(
+      port.write.mock.calls.filter(([command]) => command === "version\n"),
+    ).toHaveLength(2);
   });
 
   it("loads all settings with one bulk get and falls back only for a missing key", async () => {


### PR DESCRIPTION
## Summary

- Re-fetch the Vega version once after five seconds when the initial response has no telemetry firmware version, while cancelling stale refreshes across connection changes.
- Match the app-version label typography to the rest of the footer and bump CATS Configurator to 1.4.1.
- Add serial regression coverage for delayed telemetry startup and an Electron assertion for the footer font size.

## Testing

- ESLint
- Prettier
- Vitest: 112 tests passed
- Production electron-vite build
- Electron Playwright smoke test: 1 passed
- Release contract and 1.4.1 tag checks

## Hardware validation

- Not run against a physical Vega; the delayed telemetry behavior is covered by the serial test harness.