### PR TITLE
Fix Electron update redirect handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cats-configurator",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cats-configurator",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "plotly.js-dist-min": "^3.7.0",
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cats-configurator",
   "productName": "CATS Configurator",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Desktop configuration and flight-log analysis utility for CATS flight computers.",
   "author": "Control and Telemetry Systems GmbH",
   "private": true,

--- a/src/background.js
+++ b/src/background.js
@@ -10,6 +10,7 @@ import { setSerialWindow } from "./modules/serial.js";
 import { isAllowedExternalUrl } from "./modules/external-links.js";
 import {
   cleanupUpdates,
+  createElectronUpdateUrlResolver,
   createE2EUpdateFetch,
   initializeUpdates,
   setUpdateWindow,
@@ -133,6 +134,9 @@ async function startUpdates() {
     currentVersion: app.getVersion(),
     cacheRoot: path.join(app.getPath("userData"), "updates"),
     fetch: updateFetch,
+    resolveAssetUrl: fixturePath
+      ? undefined
+      : createElectronUpdateUrlResolver((options) => net.request(options)),
     revealFile: fixturePath
       ? () => {}
       : (filePath) => shell.showItemInFolder(filePath),

--- a/src/modules/update-manager.js
+++ b/src/modules/update-manager.js
@@ -254,6 +254,7 @@ export class UpdateManager {
     platform = process.platform,
     arch = process.arch,
     fetch,
+    resolveAssetUrl = (url) => url,
     revealFile,
     openExternal,
     enabled = true,
@@ -268,6 +269,7 @@ export class UpdateManager {
     this.platform = platform;
     this.arch = arch;
     this.fetch = fetch;
+    this.resolveAssetUrl = resolveAssetUrl;
     this.revealFile = revealFile;
     this.openExternal = openExternal;
     this.enabled = enabled;
@@ -688,71 +690,53 @@ export class UpdateManager {
   }
 
   async fetchAssetResponse(downloadUrl, signal) {
-    let currentUrl = downloadUrl;
-    for (let redirectCount = 0; redirectCount <= 5; redirectCount += 1) {
-      let headerTimer;
+    let headerTimer;
+    try {
+      headerTimer = setTimeout(
+        () =>
+          this.abortController?.abort(
+            updateError("The update download stalled.", "TIMEOUT"),
+          ),
+        this.downloadIdleTimeoutMs,
+      );
+      const headers = {
+        "User-Agent": `CATS-Configurator/${this.currentVersion}`,
+      };
+      let response;
       try {
-        headerTimer = setTimeout(
-          () =>
-            this.abortController?.abort(
-              updateError("The update download stalled.", "TIMEOUT"),
-            ),
-          this.downloadIdleTimeoutMs,
-        );
-        let response;
-        try {
-          response = await this.fetch(currentUrl, {
-            headers: {
-              "User-Agent": `CATS-Configurator/${this.currentVersion}`,
-            },
-            redirect: "manual",
-            signal,
-          });
-        } catch (error) {
-          throw networkFailure(
-            error,
-            signal,
-            "The update download could not reach GitHub.",
-          );
-        }
-        const responseUrl = response.url || currentUrl;
-        if (!isAllowedUpdateResponseUrl(responseUrl)) {
+        const resolvedUrl = await this.resolveAssetUrl(downloadUrl, {
+          headers,
+          signal,
+        });
+        if (!isAllowedUpdateResponseUrl(resolvedUrl)) {
           throw updateError(
             "The update download was redirected to an unsafe host.",
             "INVALID_URL",
           );
         }
-
-        if ([301, 302, 303, 307, 308].includes(response.status)) {
-          const location = response.headers.get("location");
-          let nextUrl;
-          try {
-            if (!location) throw new Error("Missing redirect location.");
-            nextUrl = new URL(location, responseUrl).href;
-          } catch {
-            throw updateError(
-              "The update download returned an invalid redirect.",
-              "INVALID_URL",
-            );
-          }
-          if (!isAllowedUpdateResponseUrl(nextUrl)) {
-            throw updateError(
-              "The update download was redirected to an unsafe host.",
-              "INVALID_URL",
-            );
-          }
-          currentUrl = nextUrl;
-          continue;
+        response = await this.fetch(resolvedUrl, {
+          headers,
+          redirect: "error",
+          signal,
+        });
+        if (!isAllowedUpdateResponseUrl(response.url || resolvedUrl)) {
+          throw updateError(
+            "The update download was redirected to an unsafe host.",
+            "INVALID_URL",
+          );
         }
-        return response;
-      } finally {
-        clearTimeout(headerTimer);
+      } catch (error) {
+        if (error?.code === "INVALID_URL") throw error;
+        throw networkFailure(
+          error,
+          signal,
+          "The update download could not reach GitHub.",
+        );
       }
+      return response;
+    } finally {
+      clearTimeout(headerTimer);
     }
-    throw updateError(
-      "The update download was redirected too many times.",
-      "INVALID_URL",
-    );
   }
 
   markReady(target, release, manual) {

--- a/src/modules/updates.js
+++ b/src/modules/updates.js
@@ -4,9 +4,12 @@ import path from "node:path";
 import { IPC_CHANNELS } from "../shared/ipc.js";
 import {
   expectedUpdateAssetName,
+  isAllowedUpdateResponseUrl,
   UPDATE_API_URL,
   UpdateManager,
 } from "./update-manager.js";
+
+const MAX_UPDATE_REDIRECTS = 5;
 
 let updateManager;
 let updateWindow;
@@ -51,6 +54,61 @@ export function openUpdateRelease() {
 
 export function cleanupUpdates() {
   updateManager?.stop();
+}
+
+export function createElectronUpdateUrlResolver(request) {
+  return (url, { headers = {}, signal } = {}) =>
+    new Promise((resolve, reject) => {
+      let currentUrl = url;
+      let redirectCount = 0;
+      let settled = false;
+      const clientRequest = request({
+        method: "GET",
+        url,
+        redirect: "manual",
+      });
+
+      const finish = (callback, value) => {
+        if (settled) return;
+        settled = true;
+        signal?.removeEventListener("abort", onAbort);
+        callback(value);
+      };
+      const fail = (message, code = "INVALID_URL") => {
+        const error = message instanceof Error ? message : new Error(message);
+        if (code) error.code ??= code;
+        finish(reject, error);
+        clientRequest.abort();
+      };
+      const onAbort = () =>
+        fail(signal?.reason instanceof Error ? signal.reason : "Aborted", null);
+
+      Object.entries(headers).forEach(([name, value]) =>
+        clientRequest.setHeader(name, value),
+      );
+      clientRequest.on("redirect", (_statusCode, _method, redirectUrl) => {
+        redirectCount += 1;
+        if (redirectCount > MAX_UPDATE_REDIRECTS) {
+          fail("The update download was redirected too many times.");
+          return;
+        }
+        if (!isAllowedUpdateResponseUrl(redirectUrl)) {
+          fail("The update download was redirected to an unsafe host.");
+          return;
+        }
+        currentUrl = redirectUrl;
+        clientRequest.followRedirect();
+      });
+      clientRequest.on("response", (response) => {
+        response.on("error", () => undefined);
+        finish(resolve, currentUrl);
+        clientRequest.abort();
+      });
+      clientRequest.on("error", (error) => finish(reject, error));
+      if (signal?.aborted) onAbort();
+      else signal?.addEventListener("abort", onAbort, { once: true });
+      if (!settled) clientRequest.end();
+    });
 }
 
 export async function createE2EUpdateFetch(

--- a/tests/e2e/electron.spec.js
+++ b/tests/e2e/electron.spec.js
@@ -75,7 +75,7 @@ test("launches the packaged renderer and exercises the secure bridge", async ({}
       name: "Check for updates",
     });
     await expect(statusLabel).toBeVisible();
-    await expect(appVersionButton).toContainText("App version: 1.4.1");
+    await expect(appVersionButton).toContainText("App version: 1.4.2");
     const [statusFontSize, appVersionFontSize] = await Promise.all([
       statusLabel.evaluate((element) => getComputedStyle(element).fontSize),
       appVersionButton.evaluate(

--- a/tests/unit/update-manager.test.js
+++ b/tests/unit/update-manager.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
 import {
   expectedUpdateAssetName,
   isAllowedUpdateResponseUrl,
@@ -14,6 +15,7 @@ import {
   UpdateManager,
   validateLatestRelease,
 } from "@/modules/update-manager.js";
+import { createElectronUpdateUrlResolver } from "@/modules/updates.js";
 
 const temporaryDirectories = [];
 
@@ -296,24 +298,62 @@ describe("verified update downloads", () => {
     }
   });
 
-  it("rejects an unsafe intermediate redirect before following it", async () => {
+  it("downloads only from an approved URL resolved by Electron", async () => {
     const bytes = Buffer.from("redirected installer");
     const payload = releasePayload({ bytes });
-    const fetch = vi.fn(async (url) => {
-      if (url === UPDATE_API_URL) return jsonResponse(payload);
-      return response(null, {
-        url: payload.assets[0].browser_download_url,
-        status: 302,
-        headers: { location: "https://updates.example.com/file.exe" },
-      });
+    const resolvedUrl = "https://release-assets.githubusercontent.com/file.exe";
+    const fetch = createFetch(payload, bytes, {
+      url: resolvedUrl,
     });
-    const manager = await createManager({ fetch });
+    const resolveAssetUrl = vi.fn(async () => resolvedUrl);
+    const manager = await createManager({ fetch, resolveAssetUrl });
 
     await expect(manager.check()).resolves.toMatchObject({
-      status: "error",
-      message: expect.stringContaining("unsafe host"),
+      status: "ready",
     });
-    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(resolveAssetUrl).toHaveBeenCalledWith(
+      payload.assets[0].browser_download_url,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      resolvedUrl,
+      expect.objectContaining({ redirect: "error" }),
+    );
+  });
+
+  it("validates every Electron redirect before following it", async () => {
+    const safeUrl = "https://release-assets.githubusercontent.com/file.exe";
+    const createRequest = (redirectUrl) => {
+      const request = new EventEmitter();
+      request.abort = vi.fn();
+      request.end = vi.fn(() => {
+        queueMicrotask(() => {
+          request.emit("redirect", 302, "GET", redirectUrl, {});
+          if (request.followRedirect.mock.calls.length) {
+            const response = new EventEmitter();
+            request.emit("response", response);
+          }
+        });
+      });
+      request.followRedirect = vi.fn();
+      request.setHeader = vi.fn();
+      return request;
+    };
+
+    const safeRequest = createRequest(safeUrl);
+    const safeResolver = createElectronUpdateUrlResolver(() => safeRequest);
+    await expect(safeResolver("https://github.com/file")).resolves.toBe(
+      safeUrl,
+    );
+    expect(safeRequest.followRedirect).toHaveBeenCalledOnce();
+
+    const unsafeRequest = createRequest("https://updates.example.com/file");
+    const unsafeResolver = createElectronUpdateUrlResolver(() => unsafeRequest);
+    await expect(unsafeResolver("https://github.com/file")).rejects.toThrow(
+      "unsafe host",
+    );
+    expect(unsafeRequest.followRedirect).not.toHaveBeenCalled();
   });
 
   it("rejects cache paths that could escape their version directory", async () => {


### PR DESCRIPTION
## Summary

- Fix installer downloads failing on GitHub release asset redirects in Electron.
- Validate every intermediate redirect with Electron net.request, then download only the approved final URL with automatic redirects disabled.
- Bump the app to 1.4.2 and update the packaged-renderer expectation.

## Root cause

Electron net.fetch rejects GitHub release asset redirects with `Redirect was cancelled` when redirect handling is manual. The updater reported this as being unable to reach GitHub before writing any installer bytes.

## Validation

- 113 unit tests passed.
- Release artifact contract and 1.4.2 tag checks passed.
- Production build passed.
- Electron suite: 6 passed, 1 physical-hardware test skipped.
- Post-bump packaged 1.4.2 smoke test passed.
- Live test with the actual patched update manager, simulating 1.4.0, downloaded the published 1.4.1 installer: 108,046,042 bytes with SHA-256 `3af5f0ab91a2704cffa5f72f0890a9254a677ea3d9a9b76b329f56a398caaf97`.